### PR TITLE
Update ReadEvTree.C

### DIFF
--- a/CreateLevel1Tree/ReadEvTree.C
+++ b/CreateLevel1Tree/ReadEvTree.C
@@ -455,7 +455,7 @@ void ReadEvTree::Loop(Long64_t istart, Long64_t iend)
         if (iw<pos-4 && adc<adcCut) break;
         left=iw;
       }
-      for (iw = pos; iw < (int)Slot8Data[ich]->raw.size(); iw++) {
+      for (iw = pos; iw < (int)Slot7Data[ich]->raw.size(); iw++) {
         if (Slot7Data[ich]->raw[iw]>=4095) {adcSum=-100;break;}  //skip saturated event
         float adc = Slot7Data[ich]->raw[iw] - gPed7[ich];
         if (adc<0) adc=0;


### PR DESCRIPTION
It may not be a problem, but I think the the condition should be based on the size of slot7Data[ich].size() in this for loop (since it is summing the raw elements to get the integrated sum). The code for slot8Data seems to match this scheme, just this par seems wrong. If this is a bug, it should be changed in the scripts: 
ReadEvTree_v1.0.C and ReadEvTree_v1.1.C, since they have the same line of code 